### PR TITLE
add px4 sitl model

### DIFF
--- a/ROMFS/px4fmu_common/init.d-posix/airframes/11002_hexa_y6_tilt
+++ b/ROMFS/px4fmu_common/init.d-posix/airframes/11002_hexa_y6_tilt
@@ -1,0 +1,52 @@
+#!/bin/sh
+#
+# @name Hexa Y6 Tilt copter
+#
+# @type Hexarotor Coaxial
+# @class Copter
+#
+# @maintainer Soongsil UNIV. IMS Lab. Drone-Team <alphago@soongsil.ac.kr>
+#
+# @output MAIN1 front right top, CW; angle:60; direction:CW
+# @output MAIN2 front right bottom, CCW; angle:60; direction:CCW
+# @output MAIN3 back top, CW; angle:180; direction:CW
+# @output MAIN4 back bottom, CCW; angle:180; direction:CCW
+# @output MAIN5 front left top, CW; angle:-60; direction:CW
+# @output MAIN6 front left bottom, CCW;angle:-60; direction:CCW
+#
+# @output AUX1 Motor tilt front left
+# @output AUX2 Motor tilt front right
+# @output AUX3 Motor front wheel left
+# @output AUX4 Motor front wheel right
+#
+# @board px4_fmu-v2 exclude
+# @board bitcraze_crazyflie exclude
+#
+
+. ${R}etc/init.d/rc.mc_defaults
+
+# param Custom Required
+param set-default VT_MOT_COUNT 6
+param set-default VT_FW_MOT_OFFID 3, 4
+param set-default VT_IDLE_PWM_MC 1200
+param set-default VT_TYPE 0
+param set-default VT_B_TRANS_DUR 1.0
+param set-default VT_FW_DIFTHR_EN 1
+param set-default VT_FW_DIFTHR_SC 0.17
+param set-default VT_FW_PERM_STAB 1
+param set-default VT_F_TRANS_DUR 1.2
+param set-default VT_F_TR_OL_TM 4.0
+param set-default VT_TILT_FW 1.0
+param set-default VT_TILT_MC 0.0
+param set-default VT_TILT_TRANS 0.45
+param set-default VT_TRANS_MIN_TM 1.2
+param set-default VT_TRANS_P2_DUR 1.3
+param set-default FW_ARSP_MODE 1
+set MAV_TYPE 20
+
+# Custom Mixer
+set MIXER quad_y6_vtol
+# Mixer
+set MIXER hexa_cox
+
+set PWM_OUT 12345678

--- a/ROMFS/px4fmu_common/init.d-posix/airframes/CMakeLists.txt
+++ b/ROMFS/px4fmu_common/init.d-posix/airframes/CMakeLists.txt
@@ -79,4 +79,5 @@ px4_add_romfs_files(
 	6011_typhoon_h480.post
 	6012_typhoon_ctrlalloc
 	6012_typhoon_ctrlalloc.post
+	11002_hexa_y6_tilt
 )

--- a/platforms/posix/cmake/sitl_target.cmake
+++ b/platforms/posix/cmake/sitl_target.cmake
@@ -133,6 +133,7 @@ set(models
 	typhoon_h480
 	uuv_bluerov2_heavy
 	uuv_hippocampus
+	hexa_y6_tilt
 )
 
 set(worlds


### PR DESCRIPTION
Create a folder under Tools/sitl_gazebo/models for your model, let’s call it my_vehicle
Create the following files under Tools/sitl_gazebo/models/my_vehicle: model.config and my_vehicle.sdf (these can be based off the iris or solo models in Tools/sitl_gazebo/models)
Create a world file in Tools/sitl_gazebo/worlds called my_vehicle.world (Again, this can be based off the iris or solo world files)
Create an airframe file under ROMFS/px4fmu_common/init.d-posix (Yet again, this can be based off the iris or solo airframe files), give it a number (for example 4229) and name it 4229_my_vehicle
Add the airframe name (my_vehicle) to the file platforms/posix/cmake/sitl_target.cmake in the command set(models …